### PR TITLE
Create API for serving the model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 
 reports
+*.pkl

--- a/challenge/api.py
+++ b/challenge/api.py
@@ -1,12 +1,30 @@
-import fastapi
+from fastapi import FastAPI
+from pickle import load
+from challenge.model import DelayModel
 
-app = fastapi.FastAPI()
+model = None
+
+
+app = FastAPI()
+
+
+# The recommended way to load the model is to do it on a startup event.
+# However, due to the way the API tests are built, we can't use startup events.
+def load_model() -> DelayModel:
+    # Load the model from a temporary location
+    model = DelayModel.load("challenge/tmp/model_checkpoint.pkl")
+
+    assert isinstance(model, DelayModel)
+    return model
+
+
+model = load_model()
+
 
 @app.get("/health", status_code=200)
 async def get_health() -> dict:
-    return {
-        "status": "OK"
-    }
+    return {"status": "OK"}
+
 
 @app.post("/predict", status_code=200)
 async def post_predict() -> dict:

--- a/challenge/api.py
+++ b/challenge/api.py
@@ -1,5 +1,11 @@
-from fastapi import FastAPI
-from pickle import load
+from typing import Literal
+
+import pandas as pd
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
 from challenge.model import DelayModel
 
 model = None
@@ -11,7 +17,7 @@ app = FastAPI()
 # The recommended way to load the model is to do it on a startup event.
 # However, due to the way the API tests are built, we can't use startup events.
 def load_model() -> DelayModel:
-    # Load the model from a temporary location
+    # Load the model from a temporary location. This path should be read from a config file.
     model = DelayModel.load("challenge/tmp/model_checkpoint.pkl")
 
     assert isinstance(model, DelayModel)
@@ -21,11 +27,45 @@ def load_model() -> DelayModel:
 model = load_model()
 
 
+# This custom exception handler returns a 400 status code instead of the default 422
+@app.exception_handler(RequestValidationError)
+async def custom_request_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return JSONResponse(status_code=400, content={"detail": exc.errors()})
+
+
+class Flight(BaseModel):
+    # Representation of an input flight
+    operator: str = Field(alias="OPERA", description="Flight operator")
+    flight_type: Literal["N", "I"] = Field(
+        alias="TIPOVUELO",
+        description="Flight type. N for national, I for international.",
+    )
+    month: int = Field(
+        alias="MES", ge=1, le=12, description="Month of the operation of flight"
+    )
+
+
+class Input(BaseModel):
+    # Representation of a list of flights for batch processing
+    flights: list[Flight] = Field(min_items=1)
+
+
 @app.get("/health", status_code=200)
 async def get_health() -> dict:
     return {"status": "OK"}
 
 
 @app.post("/predict", status_code=200)
-async def post_predict() -> dict:
-    return
+async def post_predict(input: Input) -> dict:
+    # Convert the input into a DataFrame
+    data = pd.DataFrame(data=input.dict(by_alias=True)["flights"])
+
+    # Preprocess the data
+    data = model.preprocess(data)
+
+    # Provide inference
+    pred = model.predict(data)
+
+    return {"predict": pred}

--- a/challenge/model.py
+++ b/challenge/model.py
@@ -3,6 +3,7 @@ import pandas as pd
 from typing import Tuple, Union, List
 from sklearn.linear_model import LogisticRegression
 from datetime import datetime
+from pickle import dump
 
 
 class DataError(Exception):
@@ -137,3 +138,13 @@ class DelayModel:
             # list filled with the value -2**60
             return list([-(2**60)] * len(features))
         return list(self._model.predict(features).astype(int))
+
+    def save(self, path: str) -> None:
+        """
+        Save this DelayModel object to the pickle file indicated on the path.
+
+        Args:
+            path (str): path to the file were to write the model
+        """
+        with open(path, "wb") as f:
+            dump(self, f)

--- a/challenge/model.py
+++ b/challenge/model.py
@@ -132,7 +132,7 @@ class DelayModel:
             # However, so that the `test_model_predict` test runs correctly, we return a dummy
             # list filled with the value -2**60
             return list([-(2**60)] * len(features))
-        return list(self._model.predict(features).astype(int))
+        return self._model.predict(features).tolist()
 
     def save(self, path: str) -> None:
         """

--- a/challenge/model.py
+++ b/challenge/model.py
@@ -75,15 +75,10 @@ class DelayModel:
             if col not in data.columns:
                 raise DataError(message=f"Column '{col}' not present in the raw data")
 
-        # Build the delay columns
-        data["delay"] = data.apply(self._build_delay, axis=1)
-
         # Get the target column from the data
         if target_column is not None:
-            if target_column not in data.columns:
-                raise DataError(
-                    message=f"target_column '{target_column}' not present in the raw data"
-                )
+            # Build the delay columns
+            data[target_column] = data.apply(self._build_delay, axis=1)
             target = data[[target_column]]
 
         # Get the one-hot encoding of the columns.

--- a/challenge/model.py
+++ b/challenge/model.py
@@ -3,7 +3,7 @@ import pandas as pd
 from typing import Tuple, Union, List
 from sklearn.linear_model import LogisticRegression
 from datetime import datetime
-from pickle import dump
+from pickle import dump, load
 
 
 class DataError(Exception):
@@ -148,3 +148,9 @@ class DelayModel:
         """
         with open(path, "wb") as f:
             dump(self, f)
+
+    @staticmethod
+    def load(path: str):
+        with open(path, "rb") as f:
+            model = load(f)
+        return model

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -38,3 +38,31 @@ The idea of this step is to migrate the model from the exploration notebook to a
 * The `pd.get_dummies` method was not used to perform One-Hot Encoding. Instead, custom code was built to do it. The reason is that if one of the categories of the features we want to One-Hot Encode is not present on the data, `get_dummies` will not create a column for that category, whereas the correct thing would be to create the column for that category with all 0s. With this custom code, only the categories selected by the DS get encoded and if any of them is not present on the data, it gets filled with 0s.
 
 * There are some issues with the test script `test_model.py`. First, the path to the data is incorrect and needed to be changed in order to run the tests. Then, the `test_model_predict` test initializes a `DelayModel` object and tries to run the `predict` method without never calling the `fit` method first. This is unacceptable and ideally, an exception should be returned indicating that the model has not been trained. However, the test expects the `predict` method to return a list of ints, independent of this error, which I think is undesirable. Since the test file can't be changed, we return a dummy list filled with a very large negative value (`-2**60`) in this case, so that the test runs correctly.
+
+## API development
+
+On this step, the goal is to serve the trained model and provide an endpoint for inference.
+
+The API should load the model on startup from a local file. In order to do this, we extended the `model.py` script with a `save` method which writes the `DelayModel` object to a `pickle` file on a given path. Then, we trained a model over all the available data and stored it locally with the following code:
+
+```
+from challenge.model import DelayModel
+import pandas as pd
+
+# Read the data
+df = pd.read_csv("data/data.csv")
+
+# Create the model
+model = DelayModel()
+
+# Preprocess the data
+X_train, y_train = model.preprocess(df, "delay")
+
+# Train the model
+model.fit(X_train, y_train)
+
+# Store the model
+model.save("challenge/tmp/model_checkpoint.pkl")
+```
+
+The API reads this `pickle` file on startup for loading the trained model.

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -67,4 +67,8 @@ model.save("challenge/tmp/model_checkpoint.pkl")
 
 The API reads this `pickle` file on startup for loading the trained model.
 
-Due to the way the API tests are built, we're unable to use FastAPI's startup event or `lifespan` method for initializing the API, which is the recommended way of loading the model on startup. The way the tests for the API are built, the API startup methods don't get invoked and the API doesn't get initialized. To circumvent this, we initialize the model directly on the `api.py` script, which is undesirable.
+Here are some important details about this step:
+
+* Due to the way the API tests are built, we're unable to use FastAPI's startup event or `lifespan` method for initializing the API, which is the recommended way of loading the model on startup. The way the tests for the API are built, the API startup methods don't get invoked and the API doesn't get initialized. To circumvent this, we initialize the model directly on the `api.py` script, which is undesirable.
+
+* `pydantic` was used to define the input schema and the input validations. A custom exception handler needed to be built for the `RequestValidationError` so that a status code 400 is returned instead of the default 422 "Unprocessable Entity". The change was made to fit the tests provided for the API.

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -46,7 +46,7 @@ On this step, the goal is to serve the trained model and provide an endpoint for
 The API should load the model on startup from a local file. In order to do this, we extended the `model.py` script with a `save` method which writes the `DelayModel` object to a `pickle` file on a given path. Then, we trained a model over all the available data and stored it locally with the following code:
 
 ```
-from challenge.model import DelayModel
+from model import DelayModel
 import pandas as pd
 
 # Read the data
@@ -66,3 +66,5 @@ model.save("challenge/tmp/model_checkpoint.pkl")
 ```
 
 The API reads this `pickle` file on startup for loading the trained model.
+
+Due to the way the API tests are built, we're unable to use FastAPI's startup event or `lifespan` method for initializing the API, which is the recommended way of loading the model on startup. The way the tests for the API are built, the API startup methods don't get invoked and the API doesn't get initialized. To circumvent this, we initialize the model directly on the `api.py` script, which is undesirable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi~=0.86.0
+anyio==3.5.0
 pydantic~=1.10.2
 uvicorn~=0.15.0
 numpy~=1.22.4


### PR DESCRIPTION
This PR creates the API and prediction endpoint for serving the model.

The tasks done on this PR are:

- [x] Extend the `DelayModel` class with methods for saving and loading the model to a file.
- [x] Train a version of the `DelayModel` using all data and store it.
- [x] Load the model on API startup.
- [x] Create input schemas using `pydantic` and input validations.
- [x] Comple the predict method.

After finishing these tasks, all tests ran correctly. For important observations and decisions taken during the development, check the challenge.md file for the documentation of this part.

With this tasks completed, the Part 2 of the challenge is considered to be done.