### PR TITLE
Deploy API to GCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,23 @@
 # syntax=docker/dockerfile:1.2
-FROM python:latest
-# put you docker configuration here
+FROM python:3.9-slim
+
+# Update system dependencies to avoid vulnerabilities
+RUN apt-get update && apt-get upgrade -y
+
+# Set the working directory
+WORKDIR /delay_model
+
+# Copy the requirements file
+COPY requirements.txt .
+
+# Install only the necessary dependencies to run the API
+RUN pip install -r requirements.txt
+
+# Copy python scripts and temp directory with the model checkpoint
+# Avoid copying the exploration notebook
+RUN mkdir challenge
+COPY challenge/*.py challenge/
+COPY challenge/tmp challenge/tmp
+
+# Start the API
+CMD ["uvicorn", "--host", "0.0.0.0", "--port", "8080", "challenge:application"]

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ install:		## Install dependencies
 	pip install -r requirements-test.txt
 	pip install -r requirements.txt
 
-STRESS_URL = http://127.0.0.1:8000 
+STRESS_URL = https://delay-model-dpmrk4cwxq-uw.a.run.app
 .PHONY: stress-test
 stress-test:
-	# change stress url to your deployed app 
+	# change stress url to your deployed app
 	mkdir reports || true
 	locust -f tests/stress/api_stress.py --print-stats --html reports/stress-test.html --run-time 60s --headless --users 100 --spawn-rate 1 -H $(STRESS_URL)
 

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -72,3 +72,17 @@ Here are some important details about this step:
 * Due to the way the API tests are built, we're unable to use FastAPI's startup event or `lifespan` method for initializing the API, which is the recommended way of loading the model on startup. The way the tests for the API are built, the API startup methods don't get invoked and the API doesn't get initialized. To circumvent this, we initialize the model directly on the `api.py` script, which is undesirable.
 
 * `pydantic` was used to define the input schema and the input validations. A custom exception handler needed to be built for the `RequestValidationError` so that a status code 400 is returned instead of the default 422 "Unprocessable Entity". The change was made to fit the tests provided for the API.
+
+
+## API deployment
+
+The goal of this step is to deploy the API on a public endpoint. To complete it, we will first build a Docker image that runs the server with the API and then deploy that Docker image to GCP.
+
+
+### Docker image
+
+The provided Dockerfile was completed so that the image is built and the API is started when the image runs inside a container.
+
+In order to use a Python version similar to the one used throughout the development, we change the base image to be the `3.9-slim`. This is a more lightweight base image and it is closer to the the version used during development (`3.9.4`).
+
+### GCP

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ black==24.4.2
 isort==5.13.2
 flake8==7.1.0
 ipykernel==6.29.4
+xgboost==2.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ coverage~=5.5
 pytest~=6.2.5
 pytest-cov~=2.12.1
 mockito~=1.2.2
+flask>=2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ uvicorn~=0.15.0
 numpy~=1.22.4
 pandas~=1.3.5
 scikit-learn~=1.3.0
-xgboost==2.1.0


### PR DESCRIPTION
This PR creates the Docker image for the API and documents the necessary steps to deploy it to GCP.

The tasks done on this PR are:

- [x] Create the Dockerfile for building the image that contains the API
- [x] Document the commands and steps done for deploying the image to GCP

After deploying the API, the stress tests ran correctly. With this tasks completed, the Part 3 of the challenge is considered to be done.